### PR TITLE
zasilkovna: Add parcel_pickup and parcel_mail_in

### DIFF
--- a/import/zasilkovna/process_file.py
+++ b/import/zasilkovna/process_file.py
@@ -163,6 +163,12 @@ try:
             if len(oh) > 0:
                 props['opening_hours'] = oh
 
+            props['parcel_pickup'] = 'yes'
+            if record['packetConsignment'] == "1":
+                props['parcel_mail_in'] = 'yes'
+            else:
+                props['parcel_mail_in'] = 'no'
+
             props['_note'] = ('<br><b>Popis:</b> %s <br><b>Stav:</b> %s ' % (record['name'], record['status']['description']))
 
             feature = Feature(geometry=Point((float(record['longitude']), float(record['latitude']))), properties=props)


### PR DESCRIPTION
Vsechny Zasilkovny jsou vydejni, v CR+SK jsou vsechny i prijmove, ale radeji osetreno dle informace z API, protoze treba v Madarsku to neplati.

Mimochodem, StreetComplete to ma jako task (viz. treba https://www.openstreetmap.org/node/11832242284#map=19/49.206456/16.626348), proto mi prijde lepsi to resit radeji hromadne.

Diky.